### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/marc2016/ioBroker.panasonic-comfort-cloud"
   },
+ "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "@types/lodash": "^4.14.199",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed with node 14 and earlier due to npm 6 not installing peerDependencies. So this adapter requires node 16 or newer